### PR TITLE
clear the array in clearCart in store/index.js

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -47,7 +47,7 @@ export default createStore({
         state.isAuthenticated = false
     },
     clearCart(state) {
-      state.cart = { items: [] }
+      state.cart.items = []
 
       localStorage.setItem('cart', JSON.stringify(state.cart))
     },


### PR DESCRIPTION
# Issue
Saw that clearCart didn't actually clear the cart during checkout when "Pay with Stripe" was successful. It still had the number of items left in the cart in the Success page [(see here in the tutorial)](https://youtu.be/Yg5zkd9nm6w?t=7999). 

# Solution
This line clears the items array in a way that Vue3 is able to detect that change